### PR TITLE
Fix to retrieve data on startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,6 +43,12 @@ func main() {
 
 	http.Handle("/metrics", promhttp.Handler())
 
+	// initial retrieval
+	err := snapshot()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	go func() {
 		ticker := time.NewTicker(time.Duration(interval) * time.Second)
 

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	// initial retrieval
 	err := snapshot()
-	if err != nil {
+	if err = nil {
 		log.Fatal(err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -44,8 +44,8 @@ func main() {
 	http.Handle("/metrics", promhttp.Handler())
 
 	// initial retrieval
-	err := snapshot()
-	if err = nil {
+	err = snapshot()
+	if err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
At the initial state right after bootstrap, the data is empty until first ticker fired.

Thanks @44smkn for the investigation