### PR TITLE
chore: Remove GOARCH from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ COPY ./main.go  ./
 
 ARG CGO_ENABLED=0
 ARG GOOS=linux
-ARG GOARCH=amd64
 RUN go build \
     -o /go/bin/aws-config-compliance-prometheus-exporter \
     -ldflags '-s -w'


### PR DESCRIPTION
The architecture during build is determined by its host architecture (such as buildx & qemu), so we should not set GOARCH in `Dockerfile`.

Follow-up:
- https://github.com/chaspy/aws-config-compliance-prometheus-exporter/pull/598